### PR TITLE
chore: bump actions/cache to v5.0.3 in node-yarn-setup

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,13 @@
+name: Smoke
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Run node-yarn-setup action
+        uses: ./

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,8 @@ runs:
     - name: Corepack
       shell: bash
       run: |
-        sudo corepack enable
-        sudo corepack prepare yarn@latest --activate
+        corepack enable
+        corepack prepare yarn@latest --activate
 
     - name: Restore NPM node_modules
       uses: actions/cache/restore@v5.0.3

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         sudo corepack prepare yarn@latest --activate
 
     - name: Restore NPM node_modules
-      uses: actions/cache/restore@v5.0.1
+      uses: actions/cache/restore@v5.0.3
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('pnpm-lock.yaml') }}
@@ -56,7 +56,7 @@ runs:
           yarn explain peer-requirements
         fi
     - name: Cache NPM dependencies
-      uses: actions/cache@v5.0.1
+      uses: actions/cache@v5.0.3
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
## Summary
- bump `actions/cache/restore` from `v5.0.1` to `v5.0.3`
- bump `actions/cache` from `v5.0.1` to `v5.0.3`
- fix `corepack` invocation by removing `sudo` so the installed Node toolchain path is used
- add local smoke workflow (`workflow_dispatch`) for deterministic `act` validation

## Validation
- `act --container-architecture linux/amd64 --container-daemon-socket - --container-options "--memory 4g" workflow_dispatch -W .github/workflows/smoke.yml -j smoke`
- result: success
