### PR TITLE
fix: use p6m7g8-actions/checkout in smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: p6m7g8-actions/checkout@main
       - name: Run node-yarn-setup action
         uses: ./


### PR DESCRIPTION
## Summary
- switch smoke workflow checkout step to p6m7g8-actions/checkout@main

## Testing
- p6_github_cli_act -W .github/workflows/smoke.yml -j smoke