### PR TITLE
chore: bump Node to 24.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
     - name: Node
       uses: p6m7g8-actions/node-yarn-setup@main
       with:
-        node-version: '24.12.0'
+        node-version: '24.14.0'
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,9 @@ author: "Philip M. Gollucci"
 
 inputs:
   node-version:
-    description: "Node.js version to install (e.g., 24.12.0)"
+    description: "Node.js version to install (e.g., 24.14.0)"
     required: false
-    default: "24.12.0"
+    default: "24.14.0"
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary
- bump action default and docs to Node 24.14.0

## Validation
- local smoke workflow run with act